### PR TITLE
Fix class name forwarding

### DIFF
--- a/docz/ComponentsAPI/html5table.mdx
+++ b/docz/ComponentsAPI/html5table.mdx
@@ -8,12 +8,12 @@ name: HTML5Table
 The `HTML5Table` component has the exact same props as the
 `WindowTable` component.
 
-The only difference is that, here, we have overriden the wrapping components.
+The main difference is that, here, we have overriden the wrapping components.
 
-Here's the code from the library, to explain that:
+Let's look at some code to understand what that means...
 
 ```jsx harmony
-const Html5Table = props => {
+const Html5TableExample = props => {
   return (
     <WindowTable
       className="table"
@@ -30,3 +30,28 @@ const Html5Table = props => {
 };
 ```
 
+In addition to that, the `Html5Table` component accepts an additional prop: `headerClassName`.
+This is convenient for cases where the `thead` components need special class names.
+
+eg:
+```jsx harmony
+<Html5Table
+    data={data}
+    columns={columns}
+    className="table-sm table-striped"
+    headerClassName="thead-dark"
+/>
+```
+
+of course, this could have been done by overriding the `Header` by yourself.
+
+```jsx harmony
+<Html5Table
+    data={data}
+    columns={columns}
+    className="table-sm table-striped"
+    Header={function THead(props) {
+      return <thead {...props} className="thead-dark" />
+    }}
+/>
+```

--- a/docz/GettingStarted/Demo.js
+++ b/docz/GettingStarted/Demo.js
@@ -34,7 +34,12 @@ function ShinobiTable() {
         height: '250px'
       }}
     >
-      <Table data={data} columns={columns} className="table-sm" />
+      <Table
+        data={data}
+        columns={columns}
+        className="table-sm table-striped"
+        headerClassName="thead-dark"
+      />
     </Bootstrap>
   );
 }

--- a/docz/GettingStarted/intro.mdx
+++ b/docz/GettingStarted/intro.mdx
@@ -21,6 +21,18 @@ Scroll as fast as you can!
 Like the idea? **Don't forget to support us by giving a Star on Github!**
 <GhStars />
 
+Now Let's have a quick look at the code we needed for the above demo.
+Note that we are using bootstrap 
+[bootstrap](https://getbootstrap.com/docs/4.1/content/tables/) table classes for styling.
+```jsx harmony
+<Html5Table
+    data={data}
+    columns={columns}
+    className="table-sm table-striped"
+    headerClassName="thead-dark"
+/>
+```
+
 ## Blazing Fast 💨
 
 Window Tables uses the awesome React Window library

--- a/docz/bootstrap.js
+++ b/docz/bootstrap.js
@@ -2,5 +2,7 @@ import React from 'react';
 import './bootstrap.scss';
 
 export default function Bootstrap(props) {
-  return <div className={`${props.className} bootstrap-wrapper`} {...props} />;
+  return (
+    <div className={`${props.className || ''} bootstrap-wrapper`} {...props} />
+  );
 }

--- a/src/Html5Table.tsx
+++ b/src/Html5Table.tsx
@@ -1,19 +1,30 @@
 import * as React from 'react';
-import WindowTable from './WindowTable';
+import WindowTable, { WindowTableProps } from './WindowTable';
 
-const THead: React.FunctionComponent<
-  React.HTMLAttributes<HTMLTableSectionElement>
-> = props => {
-  return <thead {...props} className="thead-dark" />;
+const getTHead = (headerClassName: string) => {
+  const THead: React.FunctionComponent<
+    React.HTMLAttributes<HTMLTableSectionElement>
+  > = props => {
+    return (
+      <thead {...props} className={`${headerClassName} ${props.className}`} />
+    );
+  };
+  return THead;
 };
 
-const HtmlTable: typeof WindowTable = ({ className, ...props }) => {
+interface Html5TableProps<T> extends WindowTableProps<T> {
+  headerClassName: string;
+}
+
+function Html5Table<T = any>({
+  headerClassName,
+  ...props
+}: Html5TableProps<T>) {
   return (
     <WindowTable
-      className={`${className} table`}
       Cell="td"
       HeaderCell="th"
-      Header={THead}
+      Header={getTHead(headerClassName)}
       HeaderRow="tr"
       Row="tr"
       Body="tbody"
@@ -21,6 +32,6 @@ const HtmlTable: typeof WindowTable = ({ className, ...props }) => {
       {...props}
     />
   );
-};
+}
 
-export default HtmlTable;
+export default Html5Table;

--- a/src/WindowTable.tsx
+++ b/src/WindowTable.tsx
@@ -184,6 +184,27 @@ const reducer: React.Reducer<ReducerState, MeasureAction> = (
   return state;
 };
 
+export type WindowTableProps<T> = {
+  columns: Column<keyof T, T>[];
+  data: T[];
+  height?: number;
+  width?: number;
+  rowHeight?: number;
+  overscanCount?: number;
+  style?: React.CSSProperties;
+  Cell?: React.ElementType;
+  HeaderCell?: React.ElementType;
+  Table?: React.ElementType;
+  Header?: React.ElementType;
+  HeaderRow?: React.ElementType;
+  Row?: React.ElementType;
+  Body?: React.ElementType;
+  sampleRowIndex?: number;
+  sampleRow?: T;
+  className?: string;
+  classNamePrefix?: string;
+};
+
 function WindowTable<T = any>({
   columns,
   data,
@@ -204,26 +225,7 @@ function WindowTable<T = any>({
   className = '',
   classNamePrefix = '',
   ...rest
-}: {
-  columns: Column<keyof T, T>[];
-  data: T[];
-  height?: number;
-  width?: number;
-  rowHeight?: number;
-  overscanCount?: number;
-  style?: React.CSSProperties;
-  Cell?: React.ElementType;
-  HeaderCell?: React.ElementType;
-  Table?: React.ElementType;
-  Header?: React.ElementType;
-  HeaderRow?: React.ElementType;
-  Row?: React.ElementType;
-  Body?: React.ElementType;
-  sampleRowIndex?: number;
-  sampleRow?: T;
-  className?: string;
-  classNamePrefix?: string;
-}) {
+}: WindowTableProps<T>) {
   const List: React.ElementType =
     rowHeight && typeof rowHeight === 'function'
       ? VariableSizeList
@@ -239,8 +241,10 @@ function WindowTable<T = any>({
   const bodyHeight: number = (height || tableHeight) - headerHeight;
   const effectiveWidth = width || Math.max(columnWidthsSum, tableWidth);
 
+  const tableClassName = `${classNamePrefix}table ${className}`;
+
   const TableBody: React.FunctionComponent = ({ children, ...props }) => (
-    <Table {...props} className={`${classNamePrefix}table`}>
+    <Table {...props} className={tableClassName}>
       <Body className={`${classNamePrefix}table-body`}>{children}</Body>
     </Table>
   );
@@ -255,7 +259,6 @@ function WindowTable<T = any>({
         ...style
       }}
       {...rest}
-      className={`${classNamePrefix}${className}`}
     >
       {!rowHeight && (
         /*Measure row height only if not supplied explicitly*/
@@ -267,7 +270,7 @@ function WindowTable<T = any>({
             margin: 0,
             width: `${effectiveWidth}px`
           }}
-          className={`${classNamePrefix}table`}
+          className={tableClassName}
         >
           <Body className={`${classNamePrefix}table-body`}>
             <Row className={`${classNamePrefix}table-row`}>
@@ -293,7 +296,10 @@ function WindowTable<T = any>({
         }}
       >
         <div>
-          <Table style={{ width: `${effectiveWidth}px` }}>
+          <Table
+            style={{ width: `${effectiveWidth}px`, marginBottom: 0 }}
+            className={tableClassName}
+          >
             <HeaderRowRenderer
               width={effectiveWidth}
               measure={dispatchMeasure}


### PR DESCRIPTION
[X] fix: Use empty string when className is undefined
[X] fix: Add correct className to Table components
[X] feat: Remove hardcoded thead-dark class, add option to pass header className, fix types
[X] docs: Update docs about the Html5Table API change, add demo code to intro doc

Fixes #12 