### PR TITLE
fix: Migrate from lodash-es to lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "now-dev": "docz dev"
   },
   "dependencies": {
-    "lodash-es": "^4.17.11",
+    "lodash": "^4.17.11",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.1"
   },
   "peerDependencies": {
-    "lodash-es": "^4.0.0",
+    "lodash": "^4.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-virtualized-auto-sizer": "^1.0.0",

--- a/src/Measurer.tsx
+++ b/src/Measurer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { debounce, isEqual } from 'lodash-es';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 const { useMemo, useReducer } = React;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "sourceMap": true,
     "allowJs": false,
     "jsx": "react",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "declaration": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9544,11 +9544,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
-  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
-
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"


### PR DESCRIPTION
Fixes #17 

Earlier we were using lodash-es, since it produces beautiful syntax. But considering it causes issues in certain environments, we fall back to lodash. 

However, it should be noted that the actual issue is in NextJs, as it does not transpile node_modules yet. 