### PR TITLE
Update types.tsx to match implementation

### DIFF
--- a/src/core/types.tsx
+++ b/src/core/types.tsx
@@ -39,7 +39,7 @@ export type WindowTableProps<T> = {
   sampleRowIndex?: number;
   sampleRow?: T;
   className?: string;
-  rowClassName?: string;
+  rowClassName?: string | Function;
   classNamePrefix?: string;
   debounceWait?: number;
   headerCellInnerElementType?: string;


### PR DESCRIPTION
rowClassName can be string or function.

Currently in the latest verision, typescript prevents us to define rowClassName as laid out in the examples: 
rowClassName={index => (index % 2 === 0 ? 'even-row' : 'odd-row')}