### PR TITLE
move TableBody definition outside of render function

### DIFF
--- a/docz/ComponentsAPI/windowTable.mdx
+++ b/docz/ComponentsAPI/windowTable.mdx
@@ -11,6 +11,10 @@ Note: In addition to the props documented here, all basic props such as
 `className`, `style`, `key` and all the props from the react-window itself
 can be supplied.
 
+> NOTE: If you override any of the components you must define that component 
+> outside of the render function. Otherwise state updates will make the active
+> element lose focus.
+
 ## **data**: Array
 This should be an array of objects(`key`-`value` pairs); each object representing
 a single row of the table. The `key` will be picked up by the `columns`

--- a/src/WindowTable.tsx
+++ b/src/WindowTable.tsx
@@ -18,7 +18,10 @@ const TableContext = createContext({
   data: [] as any[],
   Cell: 'div' as React.ElementType,
   Row: 'div' as React.ElementType,
+  Table: 'div' as React.ElementType,
+  Body: 'div' as React.ElementType,
   classNamePrefix: '',
+  tableClassName: '',
   rowClassName: '' as string | Function,
   rowWidthOffset: 0,
 });
@@ -153,6 +156,18 @@ const HeaderRowRenderer: React.FunctionComponent<HeaderRowProps> = ({
   );
 };
 
+const TableBodyRenderer: React.FunctionComponent = ({ children, ...props }) => {
+  const { Table, classNamePrefix, tableClassName, Body } = useContext(
+    TableContext
+  );
+
+  return (
+    <Table {...props} className={tableClassName}>
+      <Body className={`${classNamePrefix}table-body`}>{children}</Body>
+    </Table>
+  );
+};
+
 const WindowTable = React.forwardRef(
   <T extends any = any>(
     {
@@ -183,6 +198,7 @@ const WindowTable = React.forwardRef(
     ref: React.Ref<ReactWindow.FixedSizeList | ReactWindow.VariableSizeList>
   ) => {
     const measurerRowRef = useRef<HTMLElement>(null);
+    const tableClassName = `${classNamePrefix}table ${className}`;
 
     const List: React.ElementType =
       rowHeight && typeof rowHeight === 'function'
@@ -199,14 +215,6 @@ const WindowTable = React.forwardRef(
     const bodyHeight: number = (height || tableHeight) - headerHeight - 2; // 2px less to avoid possible unnecessary scrollbars
     const effectiveWidth = width || Math.max(columnWidthsSum, tableWidth);
 
-    const tableClassName = `${classNamePrefix}table ${className}`;
-
-    const TableBody: React.FunctionComponent = ({ children, ...props }) => (
-      <Table {...props} className={tableClassName}>
-        <Body className={`${classNamePrefix}table-body`}>{children}</Body>
-      </Table>
-    );
-
     const rowWidth =
       (measurerRowRef.current && measurerRowRef.current.clientWidth) ||
       tableWidth;
@@ -217,7 +225,10 @@ const WindowTable = React.forwardRef(
       data,
       Cell,
       Row,
+      Table,
+      Body,
       classNamePrefix,
+      tableClassName,
       rowClassName,
       rowWidthOffset,
     };
@@ -309,7 +320,7 @@ const WindowTable = React.forwardRef(
                 itemCount={data.length}
                 itemSize={rowHeight || sampleRowHeight}
                 width={effectiveWidth}
-                innerElementType={TableBody}
+                innerElementType={TableBodyRenderer}
                 overscanCount={overscanCount}
               >
                 {MemoRowRenderer}


### PR DESCRIPTION
I found that if I define a component renderer within a render function, state updates cause the focus to be lost. I found this issue in the underlying library as well. 

Tested this in my app and with TableBody outside of the render function the focus is retained. 

Simplified Example:

https://codesandbox.io/s/aged-meadow-54jt9?file=/src/index.js