### PR TITLE
allow string widths

### DIFF
--- a/src/core/types.tsx
+++ b/src/core/types.tsx
@@ -25,7 +25,7 @@ export type WindowTableProps<T> = {
   columns: Column<keyof T, T>[];
   data: T[];
   height?: number;
-  width?: number;
+  width?: number | string;
   rowHeight?: number;
   overscanCount?: number;
   style?: React.CSSProperties;


### PR DESCRIPTION
the react-window docs say that the width can be a string like `4rem`