### PR TITLE
add tableOuterRef and tableOuterElementType props

### DIFF
--- a/docz/ComponentsAPI/windowTable.mdx
+++ b/docz/ComponentsAPI/windowTable.mdx
@@ -294,3 +294,9 @@ element type. Not the custom cell itself.
 
 ## **tableCellInnerElementType**: string
 Same as **headerCellInnerElementType**, but for table cell.
+
+## **tableOuterRef**: `React.Ref<any>`
+Ref to attach to the outer container element of the table body.
+
+## **tableOuterElementType**: `React.Ref<any>`
+Tag name passed to document.createElement to create the outer container element of the table body.

--- a/src/WindowTable.tsx
+++ b/src/WindowTable.tsx
@@ -193,6 +193,8 @@ const WindowTable = React.forwardRef(
       debounceWait = 0,
       headerCellInnerElementType = 'div',
       tableCellInnerElementType = 'div',
+      tableOuterRef,
+      tableOuterElementType,
       ...rest
     }: WindowTableProps<T>,
     ref: React.Ref<ReactWindow.FixedSizeList | ReactWindow.VariableSizeList>
@@ -322,6 +324,8 @@ const WindowTable = React.forwardRef(
                 width={effectiveWidth}
                 innerElementType={TableBodyRenderer}
                 overscanCount={overscanCount}
+                outerRef={tableOuterRef}
+                outerElementType={tableOuterElementType}
               >
                 {MemoRowRenderer}
               </List>

--- a/src/core/types.tsx
+++ b/src/core/types.tsx
@@ -21,6 +21,11 @@ export type Column<T = string, K = any> = {
   HeaderCell?: React.ElementType;
 };
 
+export type ReactElementType =
+  | React.FunctionComponent<any>
+  | React.ComponentClass<any>
+  | string;
+
 export type WindowTableProps<T> = {
   columns: Column<keyof T, T>[];
   data: T[];
@@ -44,6 +49,8 @@ export type WindowTableProps<T> = {
   debounceWait?: number;
   headerCellInnerElementType?: string;
   tableCellInnerElementType?: string;
+  tableOuterRef?: React.Ref<any>;
+  tableOuterElementType?: ReactElementType;
 };
 
 export interface RowCellsProps {


### PR DESCRIPTION
Add props to add ref and control tag used to create outer div. You need this div to detect if `react-window` is scrolling.